### PR TITLE
backend: avoid out of bounds array access when clearing models

### DIFF
--- a/backend/modules/NosonApp/albumsmodel.cpp
+++ b/backend/modules/NosonApp/albumsmodel.cpp
@@ -229,16 +229,22 @@ void AlbumsModel::resetModel()
     if (m_dataState != ListModel::Loaded)
         return;
     beginResetModel();
-    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-    qDeleteAll(m_items);
-    m_items.clear();
-    endRemoveRows();
-    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-    foreach (AlbumItem* item, m_data)
-        m_items << item;
-    m_data.clear();
-    m_dataState = ListModel::Synced;
-    endInsertRows();
+    if (m_items.count() > 0)
+    {
+      beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+      qDeleteAll(m_items);
+      m_items.clear();
+      endRemoveRows();
+    }
+    if (m_data.count() > 0)
+    {
+      beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+      foreach (AlbumItem* item, m_data)
+          m_items << item;
+      m_data.clear();
+      m_dataState = ListModel::Synced;
+      endInsertRows();
+    }
     endResetModel();
   }
   emit countChanged();

--- a/backend/modules/NosonApp/allservicesmodel.cpp
+++ b/backend/modules/NosonApp/allservicesmodel.cpp
@@ -171,16 +171,22 @@ void AllServicesModel::resetModel()
     if (m_dataState != ListModel::Loaded)
         return;
     beginResetModel();
-    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-    qDeleteAll(m_items);
-    m_items.clear();
-    endRemoveRows();
-    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-    foreach (ServiceItem* item, m_data)
-        m_items << item;
-    m_data.clear();
-    m_dataState = ListModel::Synced;
-    endInsertRows();
+    if (m_items.count() > 0)
+    {
+      beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+      qDeleteAll(m_items);
+      m_items.clear();
+      endRemoveRows();
+    }
+    if (m_data.count() > 0)
+    {
+      beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+      foreach (ServiceItem* item, m_data)
+          m_items << item;
+      m_data.clear();
+      m_dataState = ListModel::Synced;
+      endInsertRows();
+    }
     endResetModel();
   }
   emit countChanged();

--- a/backend/modules/NosonApp/artistsmodel.cpp
+++ b/backend/modules/NosonApp/artistsmodel.cpp
@@ -204,16 +204,22 @@ void ArtistsModel::resetModel()
     if (m_dataState != ListModel::Loaded)
         return;
     beginResetModel();
-    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-    qDeleteAll(m_items);
-    m_items.clear();
-    endRemoveRows();
-    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-    foreach (ArtistItem* item, m_data)
-        m_items << item;
-    m_data.clear();
-    m_dataState = ListModel::Synced;
-    endInsertRows();
+    if (m_items.count() > 0)
+    {
+      beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+      qDeleteAll(m_items);
+      m_items.clear();
+      endRemoveRows();
+    }
+    if (m_data.count() > 0)
+    {
+      beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+      foreach (ArtistItem* item, m_data)
+          m_items << item;
+      m_data.clear();
+      m_dataState = ListModel::Synced;
+      endInsertRows();
+    }
     endResetModel();
   }
   emit countChanged();

--- a/backend/modules/NosonApp/favoritesmodel.cpp
+++ b/backend/modules/NosonApp/favoritesmodel.cpp
@@ -301,19 +301,25 @@ void FavoritesModel::resetModel()
     if (m_dataState != ListModel::Loaded)
         return;
     beginResetModel();
-    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-    qDeleteAll(m_items);
-    m_items.clear();
-    m_objectIDs.clear();
-    endRemoveRows();
-    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-    foreach (FavoriteItem* item, m_data) {
-        m_items << item;
-        m_objectIDs.insert(item->objectId(), item->id());
+    if (m_items.count() > 0)
+    {
+      beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+      qDeleteAll(m_items);
+      m_items.clear();
+      m_objectIDs.clear();
+      endRemoveRows();
     }
-    m_data.clear();
-    m_dataState = ListModel::Synced;
-    endInsertRows();
+    if (m_data.count() > 0)
+    {
+      beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+      foreach (FavoriteItem* item, m_data) {
+          m_items << item;
+          m_objectIDs.insert(item->objectId(), item->id());
+      }
+      m_data.clear();
+      m_dataState = ListModel::Synced;
+      endInsertRows();
+    }
     endResetModel();
   }
   emit countChanged();

--- a/backend/modules/NosonApp/genresmodel.cpp
+++ b/backend/modules/NosonApp/genresmodel.cpp
@@ -200,16 +200,22 @@ void GenresModel::resetModel()
     if (m_dataState != ListModel::Loaded)
         return;
     beginResetModel();
-    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-    qDeleteAll(m_items);
-    m_items.clear();
-    endRemoveRows();
-    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-    foreach (GenreItem* item, m_data)
-        m_items << item;
-    m_data.clear();
-    m_dataState = ListModel::Synced;
-    endInsertRows();
+    if (m_items.count() > 0)
+    {
+      beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+      qDeleteAll(m_items);
+      m_items.clear();
+      endRemoveRows();
+    }
+    if (m_data.count() > 0)
+    {
+      beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+      foreach (GenreItem* item, m_data)
+          m_items << item;
+      m_data.clear();
+      m_dataState = ListModel::Synced;
+      endInsertRows();
+    }
     endResetModel();
   }
   emit countChanged();

--- a/backend/modules/NosonApp/mediamodel.cpp
+++ b/backend/modules/NosonApp/mediamodel.cpp
@@ -625,16 +625,22 @@ void MediaModel::resetModel()
     if (m_dataState != ListModel::Loaded)
         return;
     beginResetModel();
-    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-    qDeleteAll(m_items);
-    m_items.clear();
-    endRemoveRows();
-    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-    foreach (MediaItem* item, m_data)
-        m_items << item;
-    m_data.clear();
-    m_dataState = ListModel::Synced;
-    endInsertRows();
+    if (m_items.count() > 0)
+    {
+      beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+      qDeleteAll(m_items);
+      m_items.clear();
+      endRemoveRows();
+    }
+    if (m_data.count() > 0)
+    {
+      beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+      foreach (MediaItem* item, m_data)
+          m_items << item;
+      m_data.clear();
+      m_dataState = ListModel::Synced;
+      endInsertRows();
+    }
     endResetModel();
   }
   emit countChanged();

--- a/backend/modules/NosonApp/playlistsmodel.cpp
+++ b/backend/modules/NosonApp/playlistsmodel.cpp
@@ -211,17 +211,24 @@ void PlaylistsModel::resetModel()
     SONOS::LockGuard lock(m_lock);
     if (m_dataState != ListModel::Loaded)
         return;
+
     beginResetModel();
-    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-    qDeleteAll(m_items);
-    m_items.clear();
-    endRemoveRows();
-    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-    foreach (PlaylistItem* item, m_data)
-        m_items << item;
-    m_data.clear();
-    m_dataState = ListModel::Synced;
-    endInsertRows();
+    if (m_items.count() > 0)
+    {
+      beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+      qDeleteAll(m_items);
+      m_items.clear();
+      endRemoveRows();
+    }
+    if (m_data.count() > 0)
+    {
+      beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+      foreach (PlaylistItem* item, m_data)
+          m_items << item;
+      m_data.clear();
+      m_dataState = ListModel::Synced;
+      endInsertRows();
+    }
     endResetModel();
   }
   emit countChanged();

--- a/backend/modules/NosonApp/queuemodel.cpp
+++ b/backend/modules/NosonApp/queuemodel.cpp
@@ -208,16 +208,22 @@ void QueueModel::resetModel()
     if (m_dataState != ListModel::Loaded)
         return;
     beginResetModel();
-    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-    qDeleteAll(m_items);
-    m_items.clear();
-    endRemoveRows();
-    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-    foreach (TrackItem* item, m_data)
-        m_items << item;
-    m_data.clear();
-    m_dataState = ListModel::Synced;
-    endInsertRows();
+    if (m_items.count() > 0)
+    {
+      beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+      qDeleteAll(m_items);
+      m_items.clear();
+      endRemoveRows();
+    }
+    if (m_data.count() > 0)
+    {
+      beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+      foreach (TrackItem* item, m_data)
+          m_items << item;
+      m_data.clear();
+      m_dataState = ListModel::Synced;
+      endInsertRows();
+    }
     endResetModel();
   }
   emit countChanged();

--- a/backend/modules/NosonApp/renderingmodel.cpp
+++ b/backend/modules/NosonApp/renderingmodel.cpp
@@ -138,15 +138,21 @@ bool RenderingModel::load(QObject* player)
 void RenderingModel::resetModel()
 {
   beginResetModel();
-  beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-  qDeleteAll(m_items);
-  m_items.clear();
-  endRemoveRows();
-  beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-  foreach (RenderingItem* item, m_data)
-      m_items << item;
-  m_data.clear();
-  endInsertRows();
+  if (m_items.count() > 0)
+  {
+    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+    qDeleteAll(m_items);
+    m_items.clear();
+    endRemoveRows();
+  }
+  if (m_data.count() > 0)
+  {
+    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+    foreach (RenderingItem* item, m_data)
+        m_items << item;
+    m_data.clear();
+    endInsertRows();
+  }
   endResetModel();
   emit countChanged();
 }

--- a/backend/modules/NosonApp/roomsmodel.cpp
+++ b/backend/modules/NosonApp/roomsmodel.cpp
@@ -175,15 +175,21 @@ bool RoomsModel::load(QObject* sonos, const QString& zoneId)
 void RoomsModel::resetModel()
 {
   beginResetModel();
-  beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-  qDeleteAll(m_items);
-  m_items.clear();
-  endRemoveRows();
-  beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-  foreach (RoomItem* item, m_data)
-      m_items << item;
-  m_data.clear();
-  endInsertRows();
+  if (m_items.count() > 0)
+  {
+    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+    qDeleteAll(m_items);
+    m_items.clear();
+    endRemoveRows();
+  }
+  if (m_data.count() > 0)
+  {
+    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+    foreach (RoomItem* item, m_data)
+        m_items << item;
+    m_data.clear();
+    endInsertRows();
+  }
   endResetModel();
   emit countChanged();
 }

--- a/backend/modules/NosonApp/servicesmodel.cpp
+++ b/backend/modules/NosonApp/servicesmodel.cpp
@@ -196,16 +196,22 @@ void ServicesModel::resetModel()
     if (m_dataState != ListModel::Loaded)
         return;
     beginResetModel();
-    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-    qDeleteAll(m_items);
-    m_items.clear();
-    endRemoveRows();
-    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-    foreach (ServiceItem* item, m_data)
-        m_items << item;
-    m_data.clear();
-    m_dataState = ListModel::Synced;
-    endInsertRows();
+    if (m_items.count() > 0)
+    {
+      beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+      qDeleteAll(m_items);
+      m_items.clear();
+      endRemoveRows();
+    }
+    if (m_data.count() > 0)
+    {
+      beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+      foreach (ServiceItem* item, m_data)
+          m_items << item;
+      m_data.clear();
+      m_dataState = ListModel::Synced;
+      endInsertRows();
+    }
     endResetModel();
   }
   emit countChanged();

--- a/backend/modules/NosonApp/tracksmodel.cpp
+++ b/backend/modules/NosonApp/tracksmodel.cpp
@@ -329,16 +329,22 @@ void TracksModel::resetModel()
     if (m_dataState != ListModel::Loaded)
         return;
     beginResetModel();
-    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-    qDeleteAll(m_items);
-    m_items.clear();
-    endRemoveRows();
-    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-    foreach (TrackItem* item, m_data)
-        m_items << item;
-    m_data.clear();
-    m_dataState = ListModel::Synced;
-    endInsertRows();
+    if (m_items.count() > 0)
+    {
+      beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+      qDeleteAll(m_items);
+      m_items.clear();
+      endRemoveRows();
+    }
+    if (m_data.count() > 0)
+    {
+      beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+      foreach (TrackItem* item, m_data)
+          m_items << item;
+      m_data.clear();
+      m_dataState = ListModel::Synced;
+      endInsertRows();
+    }
     endResetModel();
   }
   emit countChanged();

--- a/backend/modules/NosonApp/zonesmodel.cpp
+++ b/backend/modules/NosonApp/zonesmodel.cpp
@@ -181,16 +181,22 @@ void ZonesModel::resetModel()
     if (m_dataState != ListModel::Loaded)
         return;
     beginResetModel();
-    beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
-    qDeleteAll(m_items);
-    m_items.clear();
-    endRemoveRows();
-    beginInsertRows(QModelIndex(), 0, m_data.count()-1);
-    foreach (ZoneItem* item, m_data)
-        m_items << item;
-    m_data.clear();
-    m_dataState = ListModel::Synced;
-    endInsertRows();
+    if (m_items.count() > 0)
+    {
+      beginRemoveRows(QModelIndex(), 0, m_items.count()-1);
+      qDeleteAll(m_items);
+      m_items.clear();
+      endRemoveRows();
+    }
+    if (m_data.count() > 0)
+    {
+      beginInsertRows(QModelIndex(), 0, m_data.count()-1);
+      foreach (ZoneItem* item, m_data)
+          m_items << item;
+      m_data.clear();
+      m_dataState = ListModel::Synced;
+      endInsertRows();
+    }
     endResetModel();
   }
   emit countChanged();


### PR DESCRIPTION
Without these checks, we will pass an invalid length which will
cause a crash during startup otherwise.

(I wrote this patch while preparing a flatpak version of this app to submit to flathub, which I opened here: https://github.com/flathub/flathub/pull/402. Feel free to help if interested!)