### PR TITLE
Improve how desktop icon is installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ set(LIBDIR "lib/${ARCH_TRIPLET}")
 # Set install paths
 include(GNUInstallDirs)
 set(DESKTOP_DIR ${CMAKE_INSTALL_DATADIR}/applications)
-set(ICON "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/${APP_NAME}/${ICON_FILE}")
 set(PLUGINS_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${APP_NAME}")
 set(NOSON_GUI "${PLUGINS_DIR}/noson-gui")
 
@@ -50,7 +49,7 @@ install(
 
 install(
   FILES "gui/images/${ICON_FILE}"
-  DESTINATION ${CMAKE_INSTALL_DATADIR}/${APP_NAME}
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/256x256/apps
 )
 
 add_subdirectory(gui)

--- a/noson.desktop.in
+++ b/noson.desktop.in
@@ -2,7 +2,7 @@
 Name=noson
 _Comment=Sonos music
 Exec=@EXEC@
-Icon=@ICON@
+Icon=noson
 Terminal=false
 Type=Application
 


### PR DESCRIPTION
Instead of adding directly the absolute path in the desktop file, it's
best to install the icon in the standard location, and using its name
in the desktop file.