### PR TITLE
Add appdata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(APP_ID            "noson.janbar")
 set(EXEC              "noson-app")
 set(ICON_FILE         "noson.png")
 set(DESKTOP_FILE_NAME "noson.desktop")
+set(APPDATA_FILE_NAME "io.github.janbar.noson.appdata.xml")
 
 # Components PATH
 execute_process(
@@ -23,6 +24,7 @@ set(LIBDIR "lib/${ARCH_TRIPLET}")
 
 # Set install paths
 include(GNUInstallDirs)
+set(APPDATA_DIR ${CMAKE_INSTALL_DATADIR}/metainfo)
 set(DESKTOP_DIR ${CMAKE_INSTALL_DATADIR}/applications)
 set(PLUGINS_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${APP_NAME}")
 set(NOSON_GUI "${PLUGINS_DIR}/noson-gui")
@@ -50,6 +52,11 @@ install(
 install(
   FILES "gui/images/${ICON_FILE}"
   DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/256x256/apps
+)
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/${APPDATA_FILE_NAME}
+  DESTINATION ${APPDATA_DIR}
 )
 
 add_subdirectory(gui)

--- a/io.github.janbar.noson.appdata.xml
+++ b/io.github.janbar.noson.appdata.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.janbar.noson</id>
+​  <launchable type="desktop-id">noson.desktop</launchable>
+  <name>Noson</name>
+  <project_license>GPL-3.0-only</project_license>
+  <developer_name>Jean-Luc Barriere</developer_name>
+  <summary>Controller for SONOS</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <url type="homepage">http://janbar.github.io/noson-app/</url>
+  <description>
+    <p>The fast and smart controller for your SONOS devices. You can browse your music library and play track or radio on any zones. 
+    You can manage grouping zones, queue, and playlists, and fully control the playback.</p>
+  </description>
+  <screenshots>
+    <screenshot>
+      <image type="source">http://janbar.github.io/noson-app/download/noson.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release date="2018-05-23" version="3.3.6"/>
+    <release date="2018-05-21" version="3.3.5"/>
+  </releases>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>


### PR DESCRIPTION
This adds a basic appdata file to the build that I created to be able to [Add Noson to Flathub](https://github.com/flathub/flathub/pull/402). I totally cargo-culted the CMake stuff so that may be wrong.

This also ignores translations, obviously this should be all translatable, ideally you'd probably automatically generate the release tags as well.

My understanding is that there's no data sharing in the app itself, if that's wrong you might want to run the OARS questionaire yourself and update the XML: https://hughsie.github.io/oars/

I've partially adapted this from the Flatpak and DBus app-id convention (which is that your app-id must be a valid URL that you control) but you may wish to go further. We'd obviously prefer that the app named all assets it wants to export (icons, desktop files etc.) under that name, but I understand that might be more effort than you want to put in.