### PR TITLE
Add desktop categories

### DIFF
--- a/noson.desktop.in
+++ b/noson.desktop.in
@@ -5,4 +5,4 @@ Exec=@EXEC@
 Icon=@APP_NAME@
 Terminal=false
 Type=Application
-
+Categories=AudioVideo;Audio;


### PR DESCRIPTION
Software stores use the desktop categories to let users know about apps. This means your app will show up better in flathub, gnome software etc.