### PR TITLE
Port away from deprecated Qt.application.active

### DIFF
--- a/gui/noson.qml
+++ b/gui/noson.qml
@@ -100,8 +100,8 @@ ApplicationWindow {
         id: player
     }
 
-    onApplicationStateChanged: {
-        if (!noZone && applicationState && player.connected) {
+    onApplicationSuspendedChanged: {
+        if (!noZone && !applicationSuspended && player.connected) {
             mainView.jobRunning = true
             delayPlayerWakeUp.start()
         }
@@ -128,7 +128,7 @@ ApplicationWindow {
     property bool startup: true
 
     // Property to store the state of an application (active or suspended)
-    property bool applicationState: Qt.application.active
+    property bool applicationSuspended: Qt.application.state === Qt.ApplicationSuspended
 
     // setting alias to check first run
     property alias firstRun: settings.firstRun


### PR DESCRIPTION
Qt.application.active is deprecated in favor of Qt.application.state,
which also allows us to differentiate between suspended and just running
in the background (e. g. on desktop).

This also stops the loading indicator showing up every time the user
switches back to the application window.