### PR TITLE
feature: add YouTube Music via the Sonos cloud content API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ endif()
 add_subdirectory(backend)
 
 find_package(Qt${QT_VERSION_MAJOR} ${QT_VERSION} COMPONENTS
-    Core Gui Qml Quick QuickControls2 Widgets Xml Svg REQUIRED)
+    Core Gui Qml Quick QuickControls2 Widgets Xml Svg WebEngineQuick REQUIRED)
 if(QT_VERSION VERSION_GREATER_EQUAL 6)
     find_package(Qt6 ${QT_VERSION} COMPONENTS Core5Compat REQUIRED)
 endif()
@@ -209,7 +209,8 @@ target_link_libraries(noson-gui
     Qt${QT_VERSION_MAJOR}::QuickControls2
     Qt${QT_VERSION_MAJOR}::Widgets
     Qt${QT_VERSION_MAJOR}::Xml
-    Qt${QT_VERSION_MAJOR}::Svg)
+    Qt${QT_VERSION_MAJOR}::Svg
+    Qt${QT_VERSION_MAJOR}::WebEngineQuick)
 if(ANDROID)
     if(QT_VERSION_MAJOR EQUAL 5)
         target_link_libraries(noson-gui android log Qt5::AndroidExtras)

--- a/backend/NosonApp/CMakeLists.txt
+++ b/backend/NosonApp/CMakeLists.txt
@@ -5,7 +5,8 @@ set(CMAKE_AUTOMOC ON)
 option(QT_STATICPLUGIN "Build a static plugin" OFF)
 
 find_package(Qt${QT_VERSION_MAJOR} ${QT_VERSION} COMPONENTS
-    Core Gui Qml Quick REQUIRED)
+    Core Gui Qml Quick Network WebEngineCore WebEngineQuick REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR}Keychain REQUIRED)
 
 if(UNIX AND NOT APPLE)
 #    include( FindPkgConfig )
@@ -46,6 +47,8 @@ set(
     NosonApp_SOURCES
     plugin.cpp
     sonos.cpp
+    sonosaccount.cpp
+    cloudmediamodel.cpp
     player.cpp
     tracksmodel.cpp
     queuemodel.cpp
@@ -73,6 +76,8 @@ set(
     locked.h
     cppdef.h
     sonos.h
+    sonosaccount.h
+    cloudmediamodel.h
     player.h
     listmodel.h
     tracksmodel.h
@@ -120,7 +125,11 @@ set_target_properties(NosonApp PROPERTIES
 target_link_libraries(NosonApp ${noson_LIBRARIES}
     Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::Qml
-    Qt${QT_VERSION_MAJOR}::Quick)
+    Qt${QT_VERSION_MAJOR}::Quick
+    Qt${QT_VERSION_MAJOR}::Network
+    Qt${QT_VERSION_MAJOR}::WebEngineCore
+    Qt${QT_VERSION_MAJOR}::WebEngineQuick
+    Qt${QT_VERSION_MAJOR}Keychain::Qt${QT_VERSION_MAJOR}Keychain)
 
 if(HAVE_DBUS)
     target_link_libraries(NosonApp Qt${QT_VERSION_MAJOR}::DBus)

--- a/backend/NosonApp/cloudmediamodel.cpp
+++ b/backend/NosonApp/cloudmediamodel.cpp
@@ -1,0 +1,575 @@
+/*
+ *      Copyright (C) 2026
+ *
+ *  This file is part of Noson-App
+ *
+ *  Noson is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Noson is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Noson.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "cloudmediamodel.h"
+#include "sonosaccount.h"
+
+#include <noson/digitalitem.h>
+#include <noson/element.h>
+
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QUrl>
+#include <QUrlQuery>
+
+Q_DECLARE_METATYPE(SONOS::DigitalItemPtr)
+
+using namespace nosonapp;
+
+static const char* CONTENT_BASE = "https://play.sonos.com/api/content";
+static const char* BROWSER_UA   = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                                  "(KHTML, like Gecko) Chrome/140.0 Safari/537.36";
+static const char* RINC_NS      = "urn:schemas-rinconnetworks-com:metadata-1-0/";
+
+// YouTube Music's global service identity (same for every household/user).
+static const char* SERVICE_YTM = "72711"; // service type
+static const char* SID_YTM     = "284";   // service id = (72711-7)/256
+// Household + account are discovered at runtime (never hardcoded): household
+// from the local system (Muse household id), account from the household's
+// /integrations/registrations listing.
+
+CloudMediaModel::CloudMediaModel(QObject* parent)
+: QAbstractListModel(parent)
+, m_account(nullptr)
+, m_busy(false)
+, m_service(QString::fromUtf8(SERVICE_YTM))
+, m_sid(QString::fromUtf8(SID_YTM))
+{
+}
+
+CloudMediaModel::~CloudMediaModel()
+{
+}
+
+void CloudMediaModel::init(SonosAccount* account, const QString& household)
+{
+  m_account = account;
+  if (household != m_household)
+  {
+    m_household = household;
+    m_accountId.clear(); // force re-discovery for the new household
+  }
+}
+
+void CloudMediaModel::start()
+{
+  if (!m_account || !m_account->isReady())
+  {
+    emit error(tr("Not signed in"));
+    return;
+  }
+  if (m_household.isEmpty())
+  {
+    emit error(tr("No Sonos household found"));
+    return;
+  }
+  if (m_accountId.isEmpty())
+    requestRegistrations(); // discovers the account, then loads the home page
+  else
+    loadRoot();
+}
+
+// Discover which account is linked to YouTube Music on this household.
+void CloudMediaModel::requestRegistrations()
+{
+  QUrl url(QString::fromUtf8(CONTENT_BASE) +
+           QStringLiteral("/v1/households/") + m_household +
+           QStringLiteral("/integrations/registrations"));
+  QNetworkRequest req(url);
+  if (!prepare(req))
+    return;
+  setBusy(true);
+  QNetworkReply* reply = m_account->nam()->get(req);
+  connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+    reply->deleteLater();
+    setBusy(false);
+    if (reply->error() != QNetworkReply::NoError)
+    {
+      emit error(reply->errorString());
+      return;
+    }
+    const QJsonArray arr = QJsonDocument::fromJson(reply->readAll()).array();
+    for (const QJsonValue& v : arr)
+    {
+      const QJsonObject o = v.toObject();
+      if (o.value(QStringLiteral("service-id")).toString() == m_service)
+      {
+        m_accountId = o.value(QStringLiteral("account-id")).toString();
+        break;
+      }
+    }
+    if (m_accountId.isEmpty())
+      emit error(tr("YouTube Music is not connected to this household"));
+    else
+      loadRoot();
+  });
+}
+
+QHash<int, QByteArray> CloudMediaModel::roleNames() const
+{
+  QHash<int, QByteArray> r;
+  r[PayloadRole]     = "payload";
+  r[TitleRole]       = "title";
+  r[SubtitleRole]    = "subtitle";
+  r[ArtRole]         = "art";
+  r[TypeRole]        = "type";
+  r[IsContainerRole] = "isContainer";
+  r[CanPlayRole]     = "canPlay";
+  r[ObjectIdRole]    = "objectId";
+  r[HrefRole]        = "href";
+  return r;
+}
+
+int CloudMediaModel::rowCount(const QModelIndex& parent) const
+{
+  if (parent.isValid())
+    return 0;
+  return m_items.count();
+}
+
+QVariant CloudMediaModel::data(const QModelIndex& index, int role) const
+{
+  if (!index.isValid() || index.row() >= m_items.count())
+    return QVariant();
+  const CloudItem& it = m_items.at(index.row());
+  switch (role)
+  {
+  case PayloadRole:     return buildPayload(it);
+  case TitleRole:       return it.title;
+  case SubtitleRole:    return it.subtitle;
+  case ArtRole:         return it.art;
+  case TypeRole:        return it.type;
+  case IsContainerRole: return it.isContainer;
+  case CanPlayRole:     return it.canPlay;
+  case ObjectIdRole:    return it.objectId;
+  case HrefRole:        return it.href;
+  default:              return QVariant();
+  }
+}
+
+QVariantMap CloudMediaModel::get(int row) const
+{
+  QVariantMap m;
+  if (row < 0 || row >= m_items.count())
+    return m;
+  const CloudItem& it = m_items.at(row);
+  m["payload"]     = buildPayload(it);
+  m["title"]       = it.title;
+  m["subtitle"]    = it.subtitle;
+  m["art"]         = it.art;
+  m["type"]        = it.type;
+  m["isContainer"] = it.isContainer;
+  m["canPlay"]     = it.canPlay;
+  m["objectId"]    = it.objectId;
+  m["href"]        = it.href;
+  return m;
+}
+
+void CloudMediaModel::clear()
+{
+  beginResetModel();
+  m_items.clear();
+  m_stack.clear();
+  endResetModel();
+  emit countChanged();
+  emit pathChanged();
+}
+
+void CloudMediaModel::loadRoot()
+{
+  m_stack.clear();
+  Nav n; n.mode = 1; n.id = QStringLiteral("root"); n.title = tr("YouTube Music"); n.type = TypeContainer; n.href = QString();
+  m_stack.push(n);
+  emit pathChanged();
+  requestBrowse(QStringLiteral("root"), TypeContainer, QString());
+}
+
+void CloudMediaModel::search(const QString& term)
+{
+  if (term.trimmed().isEmpty())
+    return;
+  // Push onto the stack (keep the root/dashboard beneath) so the header's
+  // up navigation returns to the service home after a search.
+  Nav n; n.mode = 0; n.term = term; n.title = tr("Search: %1").arg(term); n.type = TypeContainer; n.href = QString();
+  m_stack.push(n);
+  emit pathChanged();
+  requestSearch(term);
+}
+
+void CloudMediaModel::browse(const QString& objectId, const QString& title, int type, const QString& href)
+{
+  Nav n; n.mode = 1; n.id = objectId; n.title = title; n.type = type; n.href = href;
+  m_stack.push(n);
+  emit pathChanged();
+  requestBrowse(objectId, type, href);
+}
+
+void CloudMediaModel::back()
+{
+  if (m_stack.count() <= 1)
+    return;
+  m_stack.pop();
+  emit pathChanged();
+  const Nav& n = m_stack.top();
+  if (n.mode == 0)
+    requestSearch(n.term);
+  else
+    requestBrowse(n.id, n.type, n.href);
+}
+
+// Fallback path segment when an item carries no href. Albums/containers browse
+// fine via "containers" (verified); artists/playlists use their own segment.
+QString CloudMediaModel::browseSegmentForType(int type)
+{
+  switch (type)
+  {
+  case TypePlaylist: return QStringLiteral("playlists");
+  case TypeArtist:   return QStringLiteral("artists");
+  default:           return QStringLiteral("containers");
+  }
+}
+
+// The API's item hrefs point at api.ws.sonos.com (bearer-only); rewrite them to
+// the play.sonos.com proxy so our session cookie authorizes them.
+QString CloudMediaModel::swapContentHost(const QString& href)
+{
+  QString h = href;
+  h.replace(QStringLiteral("https://api.ws.sonos.com/content/api"),
+            QStringLiteral("https://play.sonos.com/api/content"));
+  return h;
+}
+
+bool CloudMediaModel::prepare(QNetworkRequest& req)
+{
+  if (!m_account || !m_account->isReady())
+  {
+    emit error(tr("Not signed in"));
+    return false;
+  }
+  // Cookies come from the shared jar in SonosAccount::nam() (which also
+  // auto-updates the rotating JSESSIONID); do NOT set a manual Cookie header.
+  req.setRawHeader("User-Agent", BROWSER_UA);
+  req.setRawHeader("Accept", "application/json");
+  req.setRawHeader("Referer", "https://play.sonos.com/");
+  req.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+  return true;
+}
+
+void CloudMediaModel::requestSearch(const QString& term)
+{
+  QUrl url(QString::fromUtf8(CONTENT_BASE) +
+           QStringLiteral("/v1/households/") + m_household + QStringLiteral("/search"));
+  QUrlQuery q;
+  q.addQueryItem(QStringLiteral("query"), term);
+  q.addQueryItem(QStringLiteral("services"), m_service);
+  q.addQueryItem(QStringLiteral("filterExplicit"), QStringLiteral("false"));
+  url.setQuery(q);
+  QNetworkRequest req(url);
+  if (!prepare(req))
+    return;
+  setBusy(true);
+  QNetworkReply* reply = m_account->nam()->get(req);
+  connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+    reply->deleteLater();
+    setBusy(false);
+    if (reply->error() != QNetworkReply::NoError)
+    {
+      emit error(reply->errorString());
+      emit loaded(false);
+      return;
+    }
+    parseSearch(reply->readAll());
+  });
+}
+
+void CloudMediaModel::requestBrowse(const QString& objectId, int type, const QString& href)
+{
+  QUrl url;
+  if (!href.isEmpty())
+  {
+    // Authoritative: the API's own browse URL (carries filterExplicit/defaults).
+    url = QUrl(swapContentHost(href));
+  }
+  else
+  {
+    url = QUrl(QString::fromUtf8(CONTENT_BASE) +
+               QStringLiteral("/v2/households/") + m_household +
+               QStringLiteral("/services/") + m_service +
+               QStringLiteral("/accounts/") + m_accountId +
+               QStringLiteral("/") + browseSegmentForType(type) + QStringLiteral("/") + objectId +
+               QStringLiteral("/browse"));
+    QUrlQuery q;
+    q.addQueryItem(QStringLiteral("muse2"), QStringLiteral("true"));
+    // Respect the household's explicit-content setting; without this the
+    // server can filter a browse (e.g. an album) down to nothing.
+    q.addQueryItem(QStringLiteral("filterExplicit"), QStringLiteral("false"));
+    url.setQuery(q);
+  }
+  QNetworkRequest req(url);
+  if (!prepare(req))
+    return;
+  setBusy(true);
+  QNetworkReply* reply = m_account->nam()->get(req);
+  connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+    reply->deleteLater();
+    setBusy(false);
+    if (reply->error() != QNetworkReply::NoError)
+    {
+      emit error(reply->errorString());
+      emit loaded(false);
+      return;
+    }
+    parseBrowse(reply->readAll());
+  });
+}
+
+int CloudMediaModel::mapSearchType(const QString& t, bool& isContainer, bool& canPlay)
+{
+  const QString u = t.toUpper();
+  if (u == QLatin1String("TRACK") || u == QLatin1String("SONG"))
+  { isContainer = false; canPlay = true; return TypeTrack; }
+  if (u == QLatin1String("ALBUM"))
+  { isContainer = true; canPlay = true; return TypeAlbum; }
+  if (u == QLatin1String("PLAYLIST"))
+  { isContainer = true; canPlay = true; return TypePlaylist; }
+  if (u == QLatin1String("ARTIST"))
+  { isContainer = true; canPlay = false; return TypeArtist; }
+  isContainer = true; canPlay = false; return TypeContainer;
+}
+
+int CloudMediaModel::mapBrowseType(const QString& t, bool& isContainer, bool& canPlay)
+{
+  QString u = t.toUpper();
+  if (u.startsWith(QLatin1String("ITEM_")))
+    u = u.mid(5);
+  return mapSearchType(u, isContainer, canPlay);
+}
+
+static QString artFromImagesArray(const QJsonValue& images)
+{
+  // search: "images":[{"url":"..."}]
+  if (images.isArray())
+  {
+    const QJsonArray a = images.toArray();
+    if (!a.isEmpty())
+      return a.first().toObject().value(QStringLiteral("url")).toString();
+  }
+  // browse: "images":{"tile1x1":"..."}
+  if (images.isObject())
+  {
+    const QJsonObject o = images.toObject();
+    if (o.contains(QStringLiteral("tile1x1")))
+      return o.value(QStringLiteral("tile1x1")).toString();
+    for (const QJsonValue& v : o)
+      if (v.isString())
+        return v.toString();
+  }
+  return QString();
+}
+
+void CloudMediaModel::parseSearch(const QByteArray& body)
+{
+  const QJsonObject root = QJsonDocument::fromJson(body).object();
+  QList<CloudItem> items;
+  const QJsonArray services = root.value(QStringLiteral("services")).toArray();
+  for (const QJsonValue& sv : services)
+  {
+    const QJsonArray resources = sv.toObject().value(QStringLiteral("resources")).toArray();
+    for (const QJsonValue& rv : resources)
+    {
+      const QJsonObject r = rv.toObject();
+      const QJsonObject id = r.value(QStringLiteral("id")).toObject();
+      CloudItem it;
+      it.objectId = id.value(QStringLiteral("objectId")).toString();
+      it.href = r.value(QStringLiteral("href")).toString();
+      it.title = r.value(QStringLiteral("name")).toString();
+      it.subtitle = r.value(QStringLiteral("summary")).toObject().value(QStringLiteral("content")).toString();
+      it.art = artFromImagesArray(r.value(QStringLiteral("images")));
+      it.type = mapSearchType(r.value(QStringLiteral("type")).toString(), it.isContainer, it.canPlay);
+      if (r.contains(QStringLiteral("playable")) && !r.value(QStringLiteral("playable")).toBool())
+        it.canPlay = false;
+      if (!it.objectId.isEmpty() && !it.title.isEmpty())
+        items.append(it);
+    }
+  }
+  resetItems(items);
+  emit loaded(true);
+}
+
+// Recursively collect any object that looks like a content item (has
+// resource.id.objectId and a title/name). Used as a fallback for browse
+// responses whose template nests items under an unknown key.
+static void collectItemsRecursive(const QJsonValue& v, QList<QJsonObject>& out)
+{
+  if (v.isObject())
+  {
+    const QJsonObject o = v.toObject();
+    const QString oid = o.value(QStringLiteral("resource")).toObject()
+                         .value(QStringLiteral("id")).toObject()
+                         .value(QStringLiteral("objectId")).toString();
+    const bool hasTitle = o.contains(QStringLiteral("title")) || o.contains(QStringLiteral("name"));
+    if (!oid.isEmpty() && hasTitle)
+    {
+      out.append(o);
+      return; // matched item: don't descend into it
+    }
+    for (auto it = o.begin(); it != o.end(); ++it)
+      collectItemsRecursive(it.value(), out);
+  }
+  else if (v.isArray())
+  {
+    for (const QJsonValue& e : v.toArray())
+      collectItemsRecursive(e, out);
+  }
+}
+
+void CloudMediaModel::parseBrowse(const QByteArray& body)
+{
+  const QJsonObject root = QJsonDocument::fromJson(body).object();
+
+  // Collect item objects across the possible shapes:
+  //  - a normal container browse: section.items[]
+  //  - the provider home page:    sections.items[].items[]  (nested sections)
+  //  - a bare list:               items[]
+  QList<QJsonObject> raw;
+  const QJsonArray secItems = root.value(QStringLiteral("section")).toObject()
+                                  .value(QStringLiteral("items")).toArray();
+  for (const QJsonValue& v : secItems)
+    raw.append(v.toObject());
+  const QJsonArray sections = root.value(QStringLiteral("sections")).toObject()
+                                  .value(QStringLiteral("items")).toArray();
+  for (const QJsonValue& sv : sections)
+    for (const QJsonValue& v : sv.toObject().value(QStringLiteral("items")).toArray())
+      raw.append(v.toObject());
+  if (raw.isEmpty())
+    for (const QJsonValue& v : root.value(QStringLiteral("items")).toArray())
+      raw.append(v.toObject());
+  // Fallback for unknown templates (e.g. album/playlist track pages): walk the
+  // whole response, skipping the top-level container ("resource") itself.
+  if (raw.isEmpty())
+    for (auto it = root.begin(); it != root.end(); ++it)
+      if (it.key() != QStringLiteral("resource"))
+        collectItemsRecursive(it.value(), raw);
+
+  QList<CloudItem> items;
+  for (const QJsonObject& o : raw)
+  {
+    const QJsonObject res = o.value(QStringLiteral("resource")).toObject();
+    const QJsonObject id = res.value(QStringLiteral("id")).toObject();
+    CloudItem it;
+    it.objectId = id.value(QStringLiteral("objectId")).toString();
+    it.href = o.value(QStringLiteral("href")).toString();
+    it.title = o.value(QStringLiteral("title")).toString();
+    it.subtitle = o.value(QStringLiteral("subtitle")).toString();
+    it.art = artFromImagesArray(o.value(QStringLiteral("images")));
+    // Prefer resource.type (CONTAINER/PLAYLIST/ALBUM/ARTIST/TRACK); the
+    // item-level type (ITEM_AUDIO, ...) is less specific for containers.
+    QString t = res.value(QStringLiteral("type")).toString();
+    if (t.isEmpty())
+      t = o.value(QStringLiteral("type")).toString();
+    it.type = mapBrowseType(t, it.isContainer, it.canPlay);
+    if (!it.objectId.isEmpty() && !it.title.isEmpty())
+      items.append(it);
+  }
+  resetItems(items);
+  emit loaded(true);
+}
+
+void CloudMediaModel::resetItems(const QList<CloudItem>& items)
+{
+  beginResetModel();
+  m_items = items;
+  endResetModel();
+  emit countChanged();
+}
+
+QVariant CloudMediaModel::buildPayload(const CloudItem& it) const
+{
+  using namespace SONOS;
+  if (!it.canPlay || it.objectId.isEmpty())
+    return QVariant();
+
+  const std::string oid = it.objectId.toStdString();
+  const std::string sn  = m_accountId.toStdString();
+  const std::string sid = m_sid.toStdString();
+  const std::string svc = m_service.toStdString();
+  const std::string desc = std::string("SA_RINCON") + svc + "_X_#Svc" + svc + "-0-Token";
+
+  DigitalItemPtr d;
+  if (it.type == TypeTrack)
+  {
+    d = DigitalItemPtr(new DigitalItem(DigitalItem::Type_item, DigitalItem::SubType_audioItem));
+    d->SetObjectID(std::string("00032020") + oid);
+    d->SetParentID("00020000");
+    ElementPtr res(new Element("res", std::string("x-sonosapi-hls-static:") + oid +
+                               "?sid=" + sid + "&flags=8&sn=" + sn));
+    res->SetAttribut("protocolInfo", "sonos.com-http:*:application/x-mpegURL:*");
+    d->SetProperty(res);
+    d->SetProperty("upnp:class", "object.item.audioItem.musicTrack");
+  }
+  else if (it.type == TypeAlbum)
+  {
+    d = DigitalItemPtr(new DigitalItem(DigitalItem::Type_container, DigitalItem::SubType_album));
+    d->SetObjectID(std::string("0004206c") + oid);
+    d->SetParentID("00020000");
+    ElementPtr res(new Element("res", std::string("x-rincon-cpcontainer:1004206c") + oid +
+                               "?sid=" + sid + "&flags=8300&sn=" + sn));
+    res->SetAttribut("protocolInfo", "x-rincon-cpcontainer:*:*:*");
+    d->SetProperty(res);
+    d->SetProperty("upnp:class", "object.container.album.musicAlbum");
+  }
+  else if (it.type == TypePlaylist)
+  {
+    d = DigitalItemPtr(new DigitalItem(DigitalItem::Type_container, DigitalItem::SubType_playlistContainer));
+    d->SetObjectID(std::string("0006206c") + oid);
+    d->SetParentID("00020000");
+    ElementPtr res(new Element("res", std::string("x-rincon-cpcontainer:1006206c") + oid +
+                               "?sid=" + sid + "&flags=8300&sn=" + sn));
+    res->SetAttribut("protocolInfo", "x-rincon-cpcontainer:*:*:*");
+    d->SetProperty(res);
+    d->SetProperty("upnp:class", "object.container.playlistContainer");
+  }
+  else
+  {
+    return QVariant();
+  }
+
+  d->SetProperty("dc:title", it.title.toStdString());
+  if (!it.art.isEmpty())
+    d->SetProperty("upnp:albumArtURI", it.art.toStdString());
+  ElementPtr e(new Element("desc", desc));
+  e->SetAttribut("id", "cdudn");
+  e->SetAttribut("nameSpace", RINC_NS);
+  d->SetProperty(e);
+
+  return QVariant::fromValue<SONOS::DigitalItemPtr>(d);
+}
+
+void CloudMediaModel::setBusy(bool b)
+{
+  if (m_busy != b)
+  {
+    m_busy = b;
+    emit busyChanged();
+  }
+}

--- a/backend/NosonApp/cloudmediamodel.h
+++ b/backend/NosonApp/cloudmediamodel.h
@@ -1,0 +1,154 @@
+/*
+ *      Copyright (C) 2026
+ *
+ *  This file is part of Noson-App
+ *
+ *  Noson is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Noson is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Noson.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// CloudMediaModel: browses/searches a music service catalogue through the Sonos
+// consumer cloud content API (play.sonos.com), authorized by SonosAccount's
+// session cookie. Each row carries a ready-to-play SONOS::DigitalItemPtr
+// (the same payload MediaModel produces), so the existing Player enqueue path
+// (tryAddItemToQueue / tryPlayQueue) plays it unchanged.
+//
+// v1 targets YouTube Music (serviceType 72711 / sid 284). Household + account
+// are set as configurable constants (see the .cpp) pending dynamic discovery.
+
+#ifndef NOSONAPPCLOUDMEDIAMODEL_H
+#define NOSONAPPCLOUDMEDIAMODEL_H
+
+#include <QAbstractListModel>
+#include <QNetworkAccessManager>
+#include <QStack>
+#include <QVariantMap>
+
+QT_FORWARD_DECLARE_CLASS(QNetworkReply)
+
+namespace nosonapp
+{
+
+class SonosAccount;
+
+struct CloudItem
+{
+  QString title;
+  QString subtitle;
+  QString art;
+  QString objectId;
+  QString href;     // API-provided browse URL (authoritative), may be empty
+  int type;         // ItemType
+  bool isContainer;
+  bool canPlay;
+};
+
+class CloudMediaModel : public QAbstractListModel
+{
+  Q_OBJECT
+  Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
+  Q_PROPERTY(bool busy READ busy NOTIFY busyChanged)
+  Q_PROPERTY(bool canGoBack READ canGoBack NOTIFY pathChanged)
+  Q_PROPERTY(bool isRoot READ isRoot NOTIFY pathChanged)
+  Q_PROPERTY(QString pathTitle READ pathTitle NOTIFY pathChanged)
+
+public:
+  enum Roles {
+    PayloadRole = Qt::UserRole + 1,
+    TitleRole,
+    SubtitleRole,
+    ArtRole,
+    TypeRole,
+    IsContainerRole,
+    CanPlayRole,
+    ObjectIdRole,
+    HrefRole
+  };
+
+  enum ItemType {
+    TypeUnknown = 0,
+    TypeTrack,
+    TypeAlbum,
+    TypePlaylist,
+    TypeArtist,
+    TypeContainer
+  };
+  Q_ENUM(ItemType)
+
+  explicit CloudMediaModel(QObject* parent = nullptr);
+  ~CloudMediaModel() override;
+
+  Q_INVOKABLE void init(nosonapp::SonosAccount* account, const QString& household);
+  // Discover the account for the service (if needed) then load the home page.
+  Q_INVOKABLE void start();
+
+  int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+  QVariant data(const QModelIndex& index, int role) const override;
+
+  Q_INVOKABLE QVariantMap get(int row) const;
+
+  Q_INVOKABLE void loadRoot();
+  Q_INVOKABLE void search(const QString& term);
+  Q_INVOKABLE void browse(const QString& objectId, const QString& title, int type, const QString& href);
+  Q_INVOKABLE void back();
+  Q_INVOKABLE void clear();
+
+  bool busy() const { return m_busy; }
+  bool canGoBack() const { return m_stack.count() > 1; }
+  bool isRoot() const { return m_stack.count() <= 1; }
+  QString pathTitle() const { return m_stack.isEmpty() ? QString() : m_stack.top().title; }
+
+signals:
+  void countChanged();
+  void busyChanged();
+  void pathChanged();
+  void loaded(bool ok);
+  void error(const QString& message);
+
+protected:
+  QHash<int, QByteArray> roleNames() const override;
+
+private:
+  struct Nav { int mode; QString id; QString title; QString term; int type; QString href; }; // mode 0=search 1=browse
+
+  void requestSearch(const QString& term);
+  void requestBrowse(const QString& objectId, int type, const QString& href);
+  void requestRegistrations();
+  static QString browseSegmentForType(int type);
+  static QString swapContentHost(const QString& href);
+  bool prepare(QNetworkRequest& req);
+  void parseSearch(const QByteArray& body);
+  void parseBrowse(const QByteArray& body);
+  void resetItems(const QList<CloudItem>& items);
+  QVariant buildPayload(const CloudItem& it) const;
+  void setBusy(bool b);
+
+  static int mapSearchType(const QString& t, bool& isContainer, bool& canPlay);
+  static int mapBrowseType(const QString& t, bool& isContainer, bool& canPlay);
+
+  SonosAccount* m_account;
+  QNetworkAccessManager m_nam;
+  QList<CloudItem> m_items;
+  QStack<Nav> m_stack;
+  bool m_busy;
+
+  QString m_household;
+  QString m_service;   // service type, e.g. "72711"
+  QString m_sid;       // service id, e.g. "284" = (type-7)/256
+  QString m_accountId; // account serial "sn", e.g. "6"
+};
+
+}
+
+#endif // NOSONAPPCLOUDMEDIAMODEL_H

--- a/backend/NosonApp/cloudmediamodel.h
+++ b/backend/NosonApp/cloudmediamodel.h
@@ -18,15 +18,6 @@
  *
  */
 
-// CloudMediaModel: browses/searches a music service catalogue through the Sonos
-// consumer cloud content API (play.sonos.com), authorized by SonosAccount's
-// session cookie. Each row carries a ready-to-play SONOS::DigitalItemPtr
-// (the same payload MediaModel produces), so the existing Player enqueue path
-// (tryAddItemToQueue / tryPlayQueue) plays it unchanged.
-//
-// v1 targets YouTube Music (serviceType 72711 / sid 284). Household + account
-// are set as configurable constants (see the .cpp) pending dynamic discovery.
-
 #ifndef NOSONAPPCLOUDMEDIAMODEL_H
 #define NOSONAPPCLOUDMEDIAMODEL_H
 

--- a/backend/NosonApp/plugin.cpp
+++ b/backend/NosonApp/plugin.cpp
@@ -20,6 +20,8 @@
 
 #include "plugin.h"
 #include "sonos.h"
+#include "sonosaccount.h"
+#include "cloudmediamodel.h"
 #include "player.h"
 #include "future.h"
 #include "renderingmodel.h"
@@ -47,6 +49,13 @@ void NosonAppPlugin::registerTypes(const char *uri)
   qmlRegisterSingletonType<AllServicesModel>(uri, 1, 0, "AllServicesModel", Sonos::allServicesModel_provider);
   qmlRegisterSingletonType<RadiosModel>(uri, 1, 0, "AllRadiosModel", Sonos::allRadiosModel_provider);
 
+  // YouTube Music via the Sonos cloud content API (session-cookie auth)
+  qmlRegisterSingletonType<SonosAccount>(uri, 1, 0, "SonosAccount",
+      [](QQmlEngine* e, QJSEngine* s) -> QObject* {
+        Q_UNUSED(e) Q_UNUSED(s)
+        return new SonosAccount;
+      });
+
   // register noson instantiable types
   qmlRegisterType<Player>(uri, 1, 0, "ZonePlayer");
   qmlRegisterType<ZonesModel>(uri, 1, 0, "ZonesModel");
@@ -62,8 +71,11 @@ void NosonAppPlugin::registerTypes(const char *uri)
   qmlRegisterType<AlarmsModel>(uri, 1, 0, "AlarmsModel");
   qmlRegisterType<LibraryModel>(uri, 1, 0, "LibraryModel");
   qmlRegisterType<RadiosModel>(uri, 1, 0, "RadiosModel");
+  qmlRegisterType<CloudMediaModel>(uri, 1, 0, "CloudMediaModel");
 
   qRegisterMetaType<Sonos*>("Sonos*");
+  qRegisterMetaType<SonosAccount*>("SonosAccount*");
+  qRegisterMetaType<CloudMediaModel*>("CloudMediaModel*");
   qRegisterMetaType<Player*>("Player*");
   qRegisterMetaType<Future*>("Future*");
 

--- a/backend/NosonApp/sonos.cpp
+++ b/backend/NosonApp/sonos.cpp
@@ -182,6 +182,11 @@ QString Sonos::getLibVersion()
   return QString(LIBVERSION);
 }
 
+QString Sonos::museHouseholdId()
+{
+  return QString::fromUtf8(m_system.GetMuseHouseholdID().c_str());
+}
+
 void Sonos::addServiceOAuth(const QString& type, const QString& sn, const QString& key, const QString& token, const QString& username)
 {
   SONOS::System::AddServiceOAuth(type.toUtf8().constData(), sn.toUtf8().constData(), key.toUtf8().constData(), token.toUtf8().constData(), username.toUtf8().constData());

--- a/backend/NosonApp/sonos.h
+++ b/backend/NosonApp/sonos.h
@@ -100,6 +100,9 @@ public:
 
   Q_INVOKABLE QString getLibVersion();
 
+  // Muse household id (used by the cloud content API, e.g. YouTube Music)
+  Q_INVOKABLE QString museHouseholdId();
+
   Q_INVOKABLE void addServiceOAuth(const QString& type, const QString& sn, const QString& key, const QString& token, const QString& username);
   Q_INVOKABLE void deleteServiceOAuth(const QString& type, const QString& sn);
 

--- a/backend/NosonApp/sonosaccount.cpp
+++ b/backend/NosonApp/sonosaccount.cpp
@@ -217,7 +217,7 @@ void SonosAccount::onSessionReply(QNetworkReply* reply)
     }
   }
 
-  // An empty session body ({}) means the session is dead -> re-login.
+  // An empty session body ({}) means the session is dead; sign in again.
   const QJsonDocument doc = QJsonDocument::fromJson(body);
   const QJsonObject obj = doc.object();
   if (obj.isEmpty() || !obj.contains(QStringLiteral("user")))

--- a/backend/NosonApp/sonosaccount.cpp
+++ b/backend/NosonApp/sonosaccount.cpp
@@ -1,0 +1,327 @@
+/*
+ *      Copyright (C) 2026
+ *
+ *  This file is part of Noson-App
+ *
+ *  Noson is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Noson is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Noson.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "sonosaccount.h"
+
+#include <QWebEngineProfile>
+#include <QWebEngineCookieStore>
+#include <QNetworkCookie>
+#include <QNetworkCookieJar>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QTimer>
+#include <qt6keychain/keychain.h>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QUrl>
+
+using namespace nosonapp;
+
+static const char* COOKIE_NAME = "__Secure-next-auth.session-token";
+static const char* SESSION_URL = "https://play.sonos.com/api/auth/session";
+static const char* SIGNIN_URL  = "https://play.sonos.com/en-us/login?callbackUrl=https%3A%2F%2Fplay.sonos.com";
+static const char* BROWSER_UA  = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                                 "(KHTML, like Gecko) Chrome/140.0 Safari/537.36";
+// Refresh cadence: well inside the observed ~10-day rolling window.
+static const int   REFRESH_MS  = 12 * 60 * 60 * 1000;
+static const char* KEYCHAIN_SERVICE = "noson-app";
+static const char* KEYCHAIN_KEY     = "sonos-session";
+
+SonosAccount::SonosAccount(QObject* parent)
+: QObject(parent)
+, m_profile(nullptr)
+, m_timer(new QTimer(this))
+, m_status(SignedOut)
+{
+  m_timer->setInterval(REFRESH_MS);
+  connect(m_timer, &QTimer::timeout, this, &SonosAccount::refresh);
+  // Note: replies are handled per-request (below), NOT via the QNAM global
+  // finished signal, because CloudMediaModel shares this same QNAM.
+}
+
+SonosAccount::~SonosAccount()
+{
+}
+
+QString SonosAccount::signinUrl() const
+{
+  return QString::fromUtf8(SIGNIN_URL);
+}
+
+QObject* SonosAccount::webProfileObject()
+{
+  ensureProfile();
+  return m_profile;
+}
+
+void SonosAccount::ensureProfile()
+{
+  if (m_profile)
+    return;
+  // Observe the DEFAULT profile: a QML WebEngineView with no explicit profile
+  // uses QWebEngineProfile::defaultProfile(), so this is the store its cookies
+  // (including the HttpOnly session cookie) actually land in. Creating our own
+  // profile and binding it to the view proved unreliable.
+  m_profile = QWebEngineProfile::defaultProfile();
+  m_profile->setHttpUserAgent(QString::fromUtf8(BROWSER_UA));
+  connect(m_profile->cookieStore(), &QWebEngineCookieStore::cookieAdded,
+            this, [this](const QNetworkCookie& cookie) {
+      qWarning("[SonosAccount] cookieAdded name=%s domain=%s",
+               cookie.name().constData(), cookie.domain().toUtf8().constData());
+      // The v2 content API needs the server session cookie too; capture it.
+      if (cookie.name() == "JSESSIONID")
+      {
+        m_jsession = QString::fromUtf8(cookie.value());
+        qWarning("[SonosAccount] captured JSESSIONID");
+        seedJar();
+      }
+      // Match by name only: the session cookie is host-only, so domain() is
+      // often empty and must not be used to filter it out.
+      if (cookie.name() != COOKIE_NAME)
+        return;
+      QDateTime exp = cookie.expirationDate();
+      if (!exp.isValid())
+        exp = QDateTime::currentDateTimeUtc().addDays(10); // sane fallback
+      qWarning("[SonosAccount] captured session cookie (expiry %s)",
+               exp.toString(Qt::ISODate).toUtf8().constData());
+      setCookie(QString::fromUtf8(cookie.value()), exp);
+      seedJar();
+      store();
+      setStatus(Ready);
+      armTimer();
+      emit loginSucceeded();
+      // pull the account email for display (best-effort)
+      refresh();
+    });
+  emit webProfileChanged();
+}
+
+QString SonosAccount::cookieHeader() const
+{
+  if (m_cookie.isEmpty())
+    return QString();
+  QString h = QString::fromUtf8(COOKIE_NAME) + QStringLiteral("=") + m_cookie;
+  // The v2 content API (browse) also requires the server session cookie;
+  // the v1 search endpoint works without it, which is why only browse 401'd.
+  if (!m_jsession.isEmpty())
+    h += QStringLiteral("; JSESSIONID=") + m_jsession;
+  return h;
+}
+
+void SonosAccount::restore()
+{
+  // Read the stored session from the OS keychain (async).
+  QKeychain::ReadPasswordJob* job = new QKeychain::ReadPasswordJob(QString::fromUtf8(KEYCHAIN_SERVICE), this);
+  job->setKey(QString::fromUtf8(KEYCHAIN_KEY));
+  connect(job, &QKeychain::Job::finished, this, [this, job]() {
+    job->deleteLater();
+    if (job->error() == QKeychain::NoError)
+    {
+      const QJsonObject o = QJsonDocument::fromJson(job->textData().toUtf8()).object();
+      m_cookie = o.value(QStringLiteral("cookie")).toString();
+      m_jsession = o.value(QStringLiteral("jsession")).toString();
+      m_expires = QDateTime::fromString(o.value(QStringLiteral("expires")).toString(), Qt::ISODate).toUTC();
+      m_email = o.value(QStringLiteral("email")).toString();
+    }
+    if (m_cookie.isEmpty())
+    {
+      setStatus(SignedOut);
+      return;
+    }
+    if (m_expires.isValid() && QDateTime::currentDateTimeUtc() >= m_expires)
+    {
+      setStatus(Expired);
+      emit needLogin();
+      return;
+    }
+    // Valid so far: seed the jar with the stored cookie, then roll it forward
+    // (the refresh response re-seeds a fresh JSESSIONID into the jar).
+    seedJar();
+    refresh();
+  });
+  job->start();
+}
+
+void SonosAccount::beginLogin()
+{
+  webProfileObject(); // ensure profile + capture hook exist
+  setStatus(Working);
+}
+
+void SonosAccount::refresh()
+{
+  if (m_cookie.isEmpty())
+  {
+    setStatus(SignedOut);
+    return;
+  }
+  setStatus(Working);
+  seedJar(); // ensure the jar carries the current session cookie
+  QNetworkRequest req((QUrl(QString::fromUtf8(SESSION_URL))));
+  // No manual Cookie header: the shared jar sends + auto-updates the cookies.
+  req.setRawHeader("User-Agent", BROWSER_UA);
+  req.setRawHeader("Accept", "application/json");
+  req.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+  QNetworkReply* reply = m_nam.get(req);
+  connect(reply, &QNetworkReply::finished, this, [this, reply]() { onSessionReply(reply); });
+}
+
+void SonosAccount::onSessionReply(QNetworkReply* reply)
+{
+  reply->deleteLater();
+  const QByteArray body = reply->readAll();
+
+  if (reply->error() != QNetworkReply::NoError)
+  {
+    // network/auth failure: keep the cookie but mark it needing attention
+    setStatus(m_cookie.isEmpty() ? SignedOut : Expired);
+    emit needLogin();
+    return;
+  }
+
+  // Rotated Set-Cookie (NextAuth rolls the expiry on each session read).
+  const QVariant sc = reply->header(QNetworkRequest::SetCookieHeader);
+  if (sc.isValid())
+  {
+    const QList<QNetworkCookie> cookies = qvariant_cast<QList<QNetworkCookie> >(sc);
+    for (const QNetworkCookie& c : cookies)
+    {
+      if (c.name() == COOKIE_NAME)
+      {
+        QDateTime exp = c.expirationDate();
+        if (!exp.isValid())
+          exp = QDateTime::currentDateTimeUtc().addDays(10);
+        setCookie(QString::fromUtf8(c.value()), exp);
+      }
+      else if (c.name() == "JSESSIONID")
+      {
+        m_jsession = QString::fromUtf8(c.value());
+      }
+    }
+  }
+
+  // An empty session body ({}) means the session is dead -> re-login.
+  const QJsonDocument doc = QJsonDocument::fromJson(body);
+  const QJsonObject obj = doc.object();
+  if (obj.isEmpty() || !obj.contains(QStringLiteral("user")))
+  {
+    setStatus(Expired);
+    emit needLogin();
+    return;
+  }
+
+  if (obj.contains(QStringLiteral("expires")))
+  {
+    const QDateTime e = QDateTime::fromString(obj.value(QStringLiteral("expires")).toString(), Qt::ISODate);
+    if (e.isValid())
+      m_expires = e.toUTC();
+  }
+  const QJsonObject acct = obj.value(QStringLiteral("user")).toObject()
+                              .value(QStringLiteral("account")).toObject();
+  m_email = acct.value(QStringLiteral("email")).toString();
+
+  store();
+  setStatus(Ready);
+  armTimer();
+}
+
+void SonosAccount::harvestCookies()
+{
+  ensureProfile();
+  if (m_profile && m_profile->cookieStore())
+    m_profile->cookieStore()->loadAllCookies();
+}
+
+// Push the current session cookies into the shared jar for play.sonos.com.
+// The jar then sends them on every request and updates them from each
+// response's Set-Cookie (so a rotated JSESSIONID is carried forward).
+void SonosAccount::seedJar()
+{
+  if (m_cookie.isEmpty())
+    return;
+  QList<QNetworkCookie> cs;
+  QNetworkCookie sc(COOKIE_NAME, m_cookie.toUtf8());
+  sc.setPath("/");
+  cs << sc;
+  if (!m_jsession.isEmpty())
+  {
+    QNetworkCookie js("JSESSIONID", m_jsession.toUtf8());
+    js.setPath("/");
+    cs << js;
+  }
+  m_nam.cookieJar()->setCookiesFromUrl(cs, QUrl(QStringLiteral("https://play.sonos.com/")));
+}
+
+void SonosAccount::logout()
+{
+  m_cookie.clear();
+  m_jsession.clear();
+  m_expires = QDateTime();
+  m_email.clear();
+  if (m_profile && m_profile->cookieStore())
+    m_profile->cookieStore()->deleteAllCookies();
+  QKeychain::DeletePasswordJob* job = new QKeychain::DeletePasswordJob(QString::fromUtf8(KEYCHAIN_SERVICE), this);
+  job->setKey(QString::fromUtf8(KEYCHAIN_KEY));
+  connect(job, &QKeychain::Job::finished, job, &QObject::deleteLater);
+  job->start();
+  m_timer->stop();
+  setStatus(SignedOut);
+}
+
+void SonosAccount::setCookie(const QString& value, const QDateTime& expiry)
+{
+  m_cookie = value;
+  m_expires = expiry.toUTC();
+}
+
+void SonosAccount::setStatus(Status s)
+{
+  if (m_status != s)
+  {
+    m_status = s;
+    emit statusChanged();
+  }
+  else
+  {
+    // still emit so bound properties (email/expires) refresh
+    emit statusChanged();
+  }
+}
+
+void SonosAccount::armTimer()
+{
+  if (!m_timer->isActive())
+    m_timer->start();
+}
+
+// Persist the session in the OS keychain (async, fire-and-forget).
+void SonosAccount::store()
+{
+  QJsonObject o;
+  o[QStringLiteral("cookie")] = m_cookie;
+  o[QStringLiteral("jsession")] = m_jsession;
+  o[QStringLiteral("expires")] = m_expires.toString(Qt::ISODate);
+  o[QStringLiteral("email")] = m_email;
+  QKeychain::WritePasswordJob* job = new QKeychain::WritePasswordJob(QString::fromUtf8(KEYCHAIN_SERVICE), this);
+  job->setKey(QString::fromUtf8(KEYCHAIN_KEY));
+  job->setTextData(QString::fromUtf8(QJsonDocument(o).toJson(QJsonDocument::Compact)));
+  connect(job, &QKeychain::Job::finished, job, &QObject::deleteLater);
+  job->start();
+}

--- a/backend/NosonApp/sonosaccount.h
+++ b/backend/NosonApp/sonosaccount.h
@@ -1,0 +1,140 @@
+/*
+ *      Copyright (C) 2026
+ *
+ *  This file is part of Noson-App
+ *
+ *  Noson is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Noson is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Noson.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// SonosAccount: authenticates against the Sonos consumer web session
+// (play.sonos.com / NextAuth) and keeps the session cookie rolling in the
+// background. This is the credential used by the cloud content API
+// (CloudMediaModel) to browse/search a music service catalogue (e.g. YouTube
+// Music) that the local SMAPI path cannot reach without Sonos's private key.
+//
+// Login flow (QML drives a QtWebEngine WebEngineView using webProfile()):
+//   1. QML loads signinUrl() in a WebEngineView bound to webProfile().
+//   2. The user completes the Okta login; play.sonos.com sets the HttpOnly
+//      session cookie, which we capture via the profile's cookie store.
+//   3. captured -> stored -> status becomes Ready, QML closes the view.
+//
+// Refresh: GET /api/auth/session rolls the token expiry (~10 days) and returns
+// a rotated Set-Cookie; we poll it on boot and on a timer.
+
+#ifndef NOSONAPPSONOSACCOUNT_H
+#define NOSONAPPSONOSACCOUNT_H
+
+#include <QObject>
+#include <QString>
+#include <QDateTime>
+#include <QNetworkAccessManager>
+
+QT_FORWARD_DECLARE_CLASS(QWebEngineProfile)
+QT_FORWARD_DECLARE_CLASS(QTimer)
+QT_FORWARD_DECLARE_CLASS(QNetworkReply)
+
+namespace nosonapp
+{
+
+class SonosAccount : public QObject
+{
+  Q_OBJECT
+  Q_PROPERTY(int status READ status NOTIFY statusChanged)
+  Q_PROPERTY(QString email READ email NOTIFY statusChanged)
+  Q_PROPERTY(QString expires READ expiresString NOTIFY statusChanged)
+  Q_PROPERTY(QObject* webProfile READ webProfileObject NOTIFY webProfileChanged)
+  Q_PROPERTY(QString signinUrl READ signinUrl CONSTANT)
+
+public:
+  enum Status {
+    SignedOut = 0, // no stored cookie
+    Expired   = 1, // stored cookie is past its expiry -> must log in again
+    Working   = 2, // a login/refresh is in flight
+    Ready     = 3  // have a valid, refreshed cookie
+  };
+  Q_ENUM(Status)
+
+  explicit SonosAccount(QObject* parent = nullptr);
+  ~SonosAccount() override;
+
+  int status() const { return m_status; }
+  QString email() const { return m_email; }
+  QString expiresString() const { return m_expires.toString(Qt::ISODate); }
+  QString signinUrl() const;
+
+  // The QtWebEngine profile the login WebEngineView must use so that we can
+  // observe the (HttpOnly) session cookie it sets. Lazily created.
+  QObject* webProfileObject();
+
+  // The raw "name=value" cookie header value (legacy; requests now use the
+  // shared cookie jar via nam() instead). Empty when not Ready.
+  QString cookieHeader() const;
+
+  // Shared network manager whose cookie jar carries the Sonos session cookies
+  // and auto-updates from every response's Set-Cookie (handles JSESSIONID
+  // rotation). Content requests must go through this so the session stays live.
+  QNetworkAccessManager* nam() { return &m_nam; }
+
+  bool isReady() const { return m_status == Ready; }
+
+  // Boot entry point: load stored cookie; if valid, refresh; if expired,
+  // signal the UI to re-login; if none, stay SignedOut.
+  Q_INVOKABLE void restore();
+
+  // Begin an interactive login: prepares the web profile + cookie capture.
+  // The QML side opens signinUrl() in a WebEngineView bound to webProfile().
+  Q_INVOKABLE void beginLogin();
+
+  // Force a background refresh now.
+  Q_INVOKABLE void refresh();
+
+  // Force the web profile to re-emit every stored cookie (cookieAdded), so the
+  // login view can harvest the session cookie once it lands back on Sonos.
+  Q_INVOKABLE void harvestCookies();
+
+  // Clear the stored session and profile cookies.
+  Q_INVOKABLE void logout();
+
+signals:
+  void statusChanged();
+  void webProfileChanged();
+  void loginSucceeded();
+  void loginFailed(const QString& reason);
+  void needLogin(); // stored session expired / invalid
+
+private slots:
+  void onSessionReply(QNetworkReply* reply);
+
+private:
+  void ensureProfile();
+  void seedJar();
+  void setStatus(Status s);
+  void store();
+  void setCookie(const QString& value, const QDateTime& expiry);
+  void armTimer();
+
+  QNetworkAccessManager m_nam;
+  QWebEngineProfile* m_profile;
+  QTimer* m_timer;
+  Status m_status;
+  QString m_cookie;      // value of __Secure-next-auth.session-token
+  QString m_jsession;    // value of JSESSIONID (needed by the v2 content API)
+  QDateTime m_expires;   // when the session lapses
+  QString m_email;
+};
+
+}
+
+#endif // NOSONAPPSONOSACCOUNT_H

--- a/backend/NosonApp/sonosaccount.h
+++ b/backend/NosonApp/sonosaccount.h
@@ -18,21 +18,6 @@
  *
  */
 
-// SonosAccount: authenticates against the Sonos consumer web session
-// (play.sonos.com / NextAuth) and keeps the session cookie rolling in the
-// background. This is the credential used by the cloud content API
-// (CloudMediaModel) to browse/search a music service catalogue (e.g. YouTube
-// Music) that the local SMAPI path cannot reach without Sonos's private key.
-//
-// Login flow (QML drives a QtWebEngine WebEngineView using webProfile()):
-//   1. QML loads signinUrl() in a WebEngineView bound to webProfile().
-//   2. The user completes the Okta login; play.sonos.com sets the HttpOnly
-//      session cookie, which we capture via the profile's cookie store.
-//   3. captured -> stored -> status becomes Ready, QML closes the view.
-//
-// Refresh: GET /api/auth/session rolls the token expiry (~10 days) and returns
-// a rotated Set-Cookie; we poll it on boot and on a timer.
-
 #ifndef NOSONAPPSONOSACCOUNT_H
 #define NOSONAPPSONOSACCOUNT_H
 
@@ -60,7 +45,7 @@ class SonosAccount : public QObject
 public:
   enum Status {
     SignedOut = 0, // no stored cookie
-    Expired   = 1, // stored cookie is past its expiry -> must log in again
+    Expired   = 1, // stored cookie has passed its expiry; must sign in again
     Working   = 2, // a login/refresh is in flight
     Ready     = 3  // have a valid, refreshed cookie
   };

--- a/gui/controls2_640/AddService.qml
+++ b/gui/controls2_640/AddService.qml
@@ -58,7 +58,11 @@ MusicPage {
             coverSources: [{art: model.type === "65031" ? "qrc:/images/tunein.png" : model.icon}]
 
             onClicked: {
-               if (model.type !== "65031") {
+               if (model.type === "72711") {
+                   // YouTube Music: use the Sonos cloud web-login flow instead
+                   // of the gated SMAPI AppLink registration.
+                   stackView.push("qrc:/controls2/YoutubeMusic.qml");
+               } else if (model.type !== "65031") {
                    // for UserId the label is username
                    if (model.auth !== "UserId") {
                        dialogServiceLabel.serviceType = model.type;

--- a/gui/controls2_640/MusicServices.qml
+++ b/gui/controls2_640/MusicServices.qml
@@ -71,6 +71,10 @@ MusicPage {
             description: qsTr("Service")
 
             onClicked: {
+                if (model.type === "72711") {
+                    stackView.push("qrc:/controls2/YoutubeMusic.qml");
+                    return;
+                }
                 stackView.push("qrc:/controls2/Service.qml",
                                    {
                                        "serviceItem": model,
@@ -136,6 +140,10 @@ MusicPage {
             coverSources: [{art: model.type === "65031" ? "qrc:/images/tunein.png" : model.icon}]
 
             onClicked: {
+                if (model.type === "72711") {
+                    stackView.push("qrc:/controls2/YoutubeMusic.qml");
+                    return;
+                }
                 stackView.push("qrc:/controls2/Service.qml",
                                    {
                                        "serviceItem": model,

--- a/gui/controls2_640/YoutubeMusic.qml
+++ b/gui/controls2_640/YoutubeMusic.qml
@@ -14,11 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// YouTube Music via the Sonos cloud content API, laid out like the other
-// service browse pages (Service.qml): the app header drives up-navigation
-// (‹ at the root / ^ when drilled in via goUpClicked), a list/grid toggle,
-// and a search dialog. Sign-in runs an embedded Sonos login (QtWebEngine).
-
 import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtWebEngine

--- a/gui/controls2_640/YoutubeMusic.qml
+++ b/gui/controls2_640/YoutubeMusic.qml
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2026
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// YouTube Music via the Sonos cloud content API, laid out like the other
+// service browse pages (Service.qml): the app header drives up-navigation
+// (‹ at the root / ^ when drilled in via goUpClicked), a list/grid toggle,
+// and a search dialog. Sign-in runs an embedded Sonos login (QtWebEngine).
+
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtWebEngine
+import NosonApp 1.0
+import "components"
+import "components/Delegates"
+import "components/Flickables"
+
+MusicPage {
+    id: ytPage
+    objectName: "youtubeMusicPage"
+    pageTitle: qsTr("YouTube Music")
+
+    readonly property bool signedIn: SonosAccount.status === SonosAccount.Ready
+    property bool loggingIn: false
+
+    // Root when signed-out (header shows ‹ to leave) or at the service home;
+    // otherwise the header shows ^ and calls goUpClicked.
+    isRoot: !signedIn || cloudModel.isRoot
+    multiView: signedIn && !loggingIn
+    searchable: signedIn && !loggingIn
+    pageFlickable: mediaGrid.visible ? mediaGrid : mediaList
+
+    CloudMediaModel {
+        id: cloudModel
+        onError: function(message) { console.log("YouTube Music: " + message) }
+    }
+
+    Connections {
+        target: SonosAccount
+        function onLoginSucceeded() { ytPage.loggingIn = false }
+        function onNeedLogin() { ytPage.loggingIn = false }
+        function onStatusChanged() {
+            if (SonosAccount.status === SonosAccount.Ready && cloudModel.count === 0) {
+                // (Re)bind the discovered household now that the system is up,
+                // then discover the account and load the home page.
+                cloudModel.init(SonosAccount, Sonos.museHouseholdId())
+                cloudModel.start()
+            }
+        }
+    }
+
+    Component.onCompleted: {
+        cloudModel.init(SonosAccount, Sonos.museHouseholdId())
+        SonosAccount.restore()
+        if (settings.preferListView)
+            isListView = true
+    }
+
+    onGoUpClicked: cloudModel.back()
+    onListViewClicked: settings.preferListView = isListView
+    onSearchClicked: searchDialog.open()
+
+    function clickItem(model) {
+        if (model.isContainer)
+            cloudModel.browse(model.objectId, model.title, model.type, model.href)
+        else
+            trackClicked(model, true) // play the track
+    }
+
+    function playItem(model) {
+        if (!model.canPlay)
+            return
+        if (model.isContainer)
+            playAll(model)      // enqueue whole album/playlist
+        else
+            trackClicked(model, true)
+    }
+
+    // ---- Signed-out / expired prompt ----
+    Column {
+        anchors.centerIn: parent
+        width: parent.width * 0.8
+        spacing: units.gu(2)
+        visible: !ytPage.signedIn && !ytPage.loggingIn
+
+        Label {
+            width: parent.width
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            color: styleMusic.view.primaryColor
+            text: SonosAccount.status === SonosAccount.Expired
+                  ? qsTr("Your YouTube Music session expired. Please sign in again.")
+                  : qsTr("Sign in to your Sonos account to use YouTube Music.")
+        }
+        Button {
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: qsTr("Sign in")
+            onClicked: { SonosAccount.beginLogin(); ytPage.loggingIn = true }
+        }
+    }
+
+    // ---- Embedded Sonos login ----
+    WebEngineView {
+        id: loginView
+        anchors.fill: parent
+        visible: ytPage.loggingIn
+        url: ytPage.loggingIn ? SonosAccount.signinUrl : "about:blank"
+        Component.onCompleted: SonosAccount.beginLogin()
+        onLoadingChanged: function(loadRequest) {
+            if (loadRequest.status === WebEngineView.LoadSucceededStatus) {
+                var u = loadRequest.url.toString();
+                if (u.indexOf("play.sonos.com") !== -1 && u.indexOf("/login") === -1)
+                    SonosAccount.harvestCookies();
+            }
+        }
+    }
+
+    // ---- List view ----
+    MusicListView {
+        id: mediaList
+        anchors.fill: parent
+        visible: ytPage.signedIn && !ytPage.loggingIn && isListView
+        model: cloudModel
+        delegate: MusicListItem {
+            id: listItem
+            noCover: "qrc:/images/no_cover.png"
+            imageSources: model.art !== "" ? [{art: model.art}] : [{art: "qrc:/images/no_cover.png"}]
+            description: model.subtitle
+            onClicked: clickItem(model)
+            // Play triangle for playable rows (album/playlist/track)
+            actionVisible: model.canPlay
+            actionIconSource: "qrc:/images/media-preview-start.svg"
+            onActionPressed: playItem(model)
+            height: units.gu(8)
+            column: Column {
+                Label {
+                    color: styleMusic.view.primaryColor
+                    font.pointSize: units.fs("medium")
+                    text: model.title
+                }
+                Label {
+                    color: styleMusic.view.secondaryColor
+                    font.pointSize: units.fs("x-small")
+                    text: model.subtitle
+                    visible: text !== ""
+                }
+            }
+        }
+    }
+
+    // ---- Grid view ----
+    MusicGridView {
+        id: mediaGrid
+        itemWidth: units.gu(15)
+        heightOffset: units.gu(9)
+        visible: ytPage.signedIn && !ytPage.loggingIn && !isListView
+        model: cloudModel
+        delegate: Card {
+            height: mediaGrid.cellHeight
+            width: mediaGrid.cellWidth
+            primaryText: model.title
+            secondaryText: model.subtitle
+            isFavorite: false
+            canPlay: model.canPlay
+            overlay: false
+            noCover: "qrc:/images/no_cover.png"
+            coverSources: model.art !== "" ? [{art: model.art}] : [{art: "qrc:/images/no_cover.png"}]
+            onClicked: clickItem(model)
+            onPlayClicked: playItem(model)
+        }
+    }
+
+    // ---- Loading spinner ----
+    BusyIndicator {
+        anchors.centerIn: parent
+        width: units.gu(8)
+        height: units.gu(8)
+        running: cloudModel.busy
+        visible: cloudModel.busy && ytPage.signedIn && !ytPage.loggingIn
+        z: 1
+    }
+
+    // ---- Search dialog (opened from the header search button) ----
+    Dialog {
+        id: searchDialog
+        modal: true
+        anchors.centerIn: parent
+        width: Math.min(parent.width * 0.9, units.gu(50))
+        title: qsTr("Search YouTube Music")
+        standardButtons: Dialog.Ok | Dialog.Cancel
+        onOpened: { searchField.text = ""; searchField.forceActiveFocus() }
+        onAccepted: if (searchField.text.length > 0) cloudModel.search(searchField.text)
+        contentItem: TextField {
+            id: searchField
+            placeholderText: qsTr("Artist, album, song or playlist")
+            onAccepted: searchDialog.accept()
+        }
+    }
+}

--- a/gui/controls2_640/noson.qml
+++ b/gui/controls2_640/noson.qml
@@ -1227,6 +1227,7 @@ ApplicationWindow {
     ListModel {
         id: tabs
         ListElement { title: qsTr("My Services"); source: "qrc:/controls2/MusicServices.qml"; visible: true }
+        ListElement { title: qsTr("YouTube Music"); source: "qrc:/controls2/YoutubeMusic.qml"; visible: true }
         ListElement { title: qsTr("My Index"); source: "qrc:/controls2/Index.qml"; visible: true }
         ListElement { title: qsTr("My Radios"); source: "qrc:/controls2/RadioStations.qml"; visible: true }
         ListElement { title: qsTr("Favorites"); source: "qrc:/controls2/Favorites.qml"; visible: false }

--- a/gui/controls2_640/noson.qml
+++ b/gui/controls2_640/noson.qml
@@ -1227,7 +1227,6 @@ ApplicationWindow {
     ListModel {
         id: tabs
         ListElement { title: qsTr("My Services"); source: "qrc:/controls2/MusicServices.qml"; visible: true }
-        ListElement { title: qsTr("YouTube Music"); source: "qrc:/controls2/YoutubeMusic.qml"; visible: true }
         ListElement { title: qsTr("My Index"); source: "qrc:/controls2/Index.qml"; visible: true }
         ListElement { title: qsTr("My Radios"); source: "qrc:/controls2/RadioStations.qml"; visible: true }
         ListElement { title: qsTr("Favorites"); source: "qrc:/controls2/Favorites.qml"; visible: false }

--- a/gui/noson_controls2_640.qrc
+++ b/gui/noson_controls2_640.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/">
         <file alias="controls2/noson.qml">controls2_640/noson.qml</file>
+        <file alias="controls2/YoutubeMusic.qml">controls2_640/YoutubeMusic.qml</file>
         <file alias="controls2/qtquickcontrols2.conf">controls2_640/qtquickcontrols2.conf</file>
         <file alias="controls2/NoZoneState.qml">controls2_640/NoZoneState.qml</file>
         <file alias="controls2/components/ActivitySpinner.qml">controls2_640/components/ActivitySpinner.qml</file>

--- a/src/noson.cpp
+++ b/src/noson.cpp
@@ -8,6 +8,7 @@
 #include <QQmlContext>
 #include <QSettings>
 #include <QtQuickControls2>
+#include <QtWebEngineQuick>
 #include <QTranslator>
 #include <QLibraryInfo>
 #include <QDebug>
@@ -77,8 +78,13 @@ int main(int argc, char *argv[])
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
+    // QtWebEngine (YouTube Music login webview) needs a shared GL context;
+    // this attribute must be set before the QGuiApplication is constructed.
+    QGuiApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
     QGuiApplication app(argc, argv);
     setupApp(app);
+    // Initialize QtWebEngine before loading any QML that imports QtWebEngine.
+    QtWebEngineQuick::initialize();
 
     QSettings settings;
     QStringList availableStyles;


### PR DESCRIPTION
NOTE: depends on https://github.com/janbar/noson/pull/23

the YouTube Music service integration was broken due to the AppLink authentication process consuming the `music.googleapis.com` service without including the necessary API key. this caused a 403 forbidden from the Google API, and the error was not handled within noson-app.

inspection of the 403 revealed that this is a partner API and there is no way to retrieve the unencrypted API key as it was issued directly to Sonos. since the necessary SMAPI endpoints are implemented by music content partners, there is no direct way to proxy various music service commands through the Sonos device. finally, Sonos uses a YouTube ID encryption/obfuscation process resulting in errors if you try to pass a plain YouTube ID to the speaker via local UPnP (HTTP 500/UPnPError errorCode 800).

the solution implements a prompt for the user to login to their Sonos account to obtain a cookie that can be used with the Sonos web-app player's API to proxy the requests through the direct Sonos-YouTube connection. this allows noson-app to retrieve these encrypted/obfuscated IDs directly from Sonos (in addition to handling search, playlist retrieval, etc). search/browse happens through the cloud, playback stays local UPnP.

login is handled via Qt WebEngine and session cookie is stored in OS keychain via qtkeychain. auth + content share one
QTNetworkAccessManager/cookie jar so JSESSIONID rotations are carried forward. session cookie is rotated on a timer as well as on app load to ensure freshness. if expired, the user is prompted to login again to capture a fresh cookie.